### PR TITLE
Fix play/pause symbol behavior if multiple bars have the same name

### DIFF
--- a/get_spotify_status.sh
+++ b/get_spotify_status.sh
@@ -20,7 +20,7 @@ FORMAT="{{ title }} - {{ artist }}"
 update_hooks() {
     while IFS= read -r id
     do
-        polybar-msg -p "$id" hook playerctl-play-pause $2 1>/dev/null 2>&1
+        polybar-msg -p "$id" hook spotify-play-pause $2 1>/dev/null 2>&1
     done < <(echo "$1")
 }
 

--- a/get_spotify_status.sh
+++ b/get_spotify_status.sh
@@ -16,6 +16,14 @@ PLAYER="spotify"
 # See more attributes here: https://github.com/altdesktop/playerctl/#printing-properties-and-metadata
 FORMAT="{{ title }} - {{ artist }}"
 
+# Sends $2 as message to all polybar PIDs that are part of $1
+update_hooks() {
+    while IFS= read -r id
+    do
+        polybar-msg -p "$id" hook playerctl-play-pause $2 1>/dev/null 2>&1
+    done < <(echo "$1")
+}
+
 PLAYERCTL_STATUS=$(playerctl --player=$PLAYER status 2>/dev/null)
 EXIT_CODE=$?
 
@@ -31,12 +39,12 @@ else
     if [ "$STATUS" = "Stopped" ]; then
         echo "No music is playing"
     elif [ "$STATUS" = "Paused"  ]; then
-        polybar-msg -p "$PARENT_BAR_PID" hook spotify-play-pause 2 1>/dev/null 2>&1
+        update_hooks "$PARENT_BAR_PID" 2
         playerctl --player=$PLAYER metadata --format "$FORMAT"
     elif [ "$STATUS" = "No player is running"  ]; then
         echo "$STATUS"
     else
-        polybar-msg -p "$PARENT_BAR_PID" hook spotify-play-pause 1 1>/dev/null 2>&1
+        update_hooks "$PARENT_BAR_PID" 1
         playerctl --player=$PLAYER metadata --format "$FORMAT"
     fi
 fi


### PR DESCRIPTION
The get_spotify_status.sh now sends messages to each Polybar with matching name

I hope this PR is properly formatted, I'm new to GitHub collaboration and bash programming :/