### PR TITLE
Update playerctl command in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,20 +44,20 @@ exec = ~/.config/polybar/scripts/scroll_spotify_status.sh
 type = custom/script
 exec = echo "<previous-song-symbol>"
 format = <label>
-click-left = playerctl previous spotify
+click-left = playerctl --player=spotify previous 
 
 [module/spotify-play-pause]
 type = custom/ipc
 hook-0 = echo "<playing-symbol>"
 hook-1 = echo "<pause-symbol>"
 initial = 1
-click-left = playerctl play-pause spotify
+click-left = playerctl --player=spotify play-pause
 
 [module/spotify-next]
 type = custom/script
 exec = echo "next-song-symbol"
 format = <label>
-click-left = playerctl next spotify
+click-left =  playerctl --player=spotify next
 ```
 
 NOTE: The above given play-pause module requires IPC support enabled for its parent bar. That can be done by adding `enable-ipc = true` in your bar config.


### PR DESCRIPTION
Hello, using this module for some days I've a problem with playerctl when I was watching something on youtube, and I clicked to spotify pause current music, youtube video was paused, so I read playerctl doc and find a way to specify spotify on the command, using: 
```sh
playerctl --player=spotify next/play-pause/previous
```
In old command playerctl was sending to first player runing on the machine, in the new way only to spotify.
And I just implemented this to README.md file.