### PR TITLE
Suggestion of how to reference files

### DIFF
--- a/get_spotify_status.sh
+++ b/get_spotify_status.sh
@@ -48,3 +48,4 @@ else
         playerctl --player=$PLAYER metadata --format "$FORMAT"
     fi
 fi
+

--- a/scroll_spotify_status.sh
+++ b/scroll_spotify_status.sh
@@ -4,9 +4,10 @@
 zscroll -l 30 \
         --delay 0.1 \
         --scroll-padding "  " \
-        --match-command "$HOME/.config/polybar/scripts/get_spotify_status.sh --status" \
+        --match-command "`dirname $0`/get_spotify_status.sh --status" \
         --match-text "Playing" "--scroll 1" \
         --match-text "Paused" "--scroll 0" \
-        --update-check true "$HOME/.config/polybar/scripts/get_spotify_status.sh" &
+        --update-check true "`dirname $0`/get_spotify_status.sh" &
 
 wait
+


### PR DESCRIPTION
It would be better for each individual to be able to choose where to place the script.
The reference to get_spotify_status for scroll_spotify_status.sh is now a relative reference