### PR TITLE
Option to reset scrolled text when paused.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ PLAYER="playerctld"
 # Eg. {{ artist }} - {{ album }} - {{ title }}
 # See more attributes here: https://github.com/altdesktop/playerctl/#printing-properties-and-metadata
 FORMAT="{{ title }} - {{ artist }}"
+
+# Reset text position when paused.
+# Default is 0, set to 1 to enable.
+# This option makes it reset text to start of format instead of
+# leaving it scrolled in the middle.
+RESET_ON_PAUSE=0
 ```
 - Add the following in your polybar config.
 Make sure to place the desired symbols for each module. You can get them from like [Font Awesome](https://fontawesome.com/cheatsheet) or [Nerd Fonts](https://www.nerdfonts.com/cheat-sheet).

--- a/get_spotify_status.sh
+++ b/get_spotify_status.sh
@@ -16,6 +16,12 @@ PLAYER="spotify"
 # See more attributes here: https://github.com/altdesktop/playerctl/#printing-properties-and-metadata
 FORMAT="{{ title }} - {{ artist }}"
 
+# Reset text position when paused.
+# Default is 0, set to 1 to enable.
+# This option makes it reset text to start of format instead of
+# leaving it scrolled in the middle.
+RESET_ON_PAUSE=0
+
 # Sends $2 as message to all polybar PIDs that are part of $1
 update_hooks() {
     while IFS= read -r id
@@ -23,6 +29,12 @@ update_hooks() {
         polybar-msg -p "$id" hook spotify-play-pause $2 1>/dev/null 2>&1
     done < <(echo "$1")
 }
+
+# if reset on pause enabled, insert zero width space before format when paused. This will reset the text
+PAUSED_PREFIX=""
+if [ "$RESET_ON_PAUSE" == "1" ]; then
+    PAUSED_PREFIX="$(printf '\u200B')"
+fi
 
 PLAYERCTL_STATUS=$(playerctl --player=$PLAYER status 2>/dev/null)
 EXIT_CODE=$?
@@ -40,7 +52,7 @@ else
         echo "No music is playing"
     elif [ "$STATUS" = "Paused"  ]; then
         update_hooks "$PARENT_BAR_PID" 2
-        playerctl --player=$PLAYER metadata --format "$FORMAT"
+        playerctl --player=$PLAYER metadata --format "$PAUSED_PREFIX$FORMAT"
     elif [ "$STATUS" = "No player is running"  ]; then
         echo "$STATUS"
     else


### PR DESCRIPTION
Implemented by inserting w zero-width space before format.

Reason:
Currently, in certain configuration, when the player (spotify) is paused, the output on the module can be weirdly scrolled to the middle. Example `ave You Done - Within Te`.
Whereas with reset on pause enabled, the text would reset to `What Have You Done - With`.